### PR TITLE
fix: n8n rm empty install file

### DIFF
--- a/n8n/.env.example
+++ b/n8n/.env.example
@@ -5,6 +5,8 @@ N8N_USER_MANAGEMENT_JWT_SECRET=your_user_management_jwt_secret
 # Analytics and Telemetry (Disable if desired)
 N8N_DIAGNOSTICS_ENABLED=false
 N8N_DISABLE_EDITOR_SELF_HOSTED=true
+NEN_SECURE_COOKIE=true
+
 GENERIC_TIMEZONE=Etc/GMT+3
 TZ=Etc/GMT
 

--- a/n8n/docker-compose.override-proxy.yml
+++ b/n8n/docker-compose.override-proxy.yml
@@ -13,7 +13,7 @@ services:
       - VIRTUAL_PORT
       - LETSENCRYPT_HOST
       - LETSENCRYPT_EMAIL
-      - N8N_SECURE_COOKIE=false
+      - N8N_SECURE_COOKIE
     ports: []
     expose: 
       - 5678


### PR DESCRIPTION
Remove secure cookies to allow localhost deployment