### PR TITLE
build: upgrade botpress

### DIFF
--- a/botpress/botpress/Dockerfile
+++ b/botpress/botpress/Dockerfile
@@ -1,3 +1,3 @@
-FROM botpress/server:v12_27_0
+FROM botpress/server:latest
 WORKDIR /botpress
 CMD ["./bp"]

--- a/botpress/docker-compose.yml
+++ b/botpress/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+# version: '3'
 
 services:
   botpress:

--- a/botpress/docker-compose.yml
+++ b/botpress/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     container_name: botpress-server
     command: /botpress/bp
     ports:
-      - 3000:3000
+      - 3030:3000
     env_file: botpress.env
     depends_on:
       - postgres


### PR DESCRIPTION
Changelog:
* Uses latest `botpress/server` Docker image
* Deprecates the `version: x.x` directive in Docker Compose
* Listens on host port `3030` instead of `3000` (used by a lot of dev environments)